### PR TITLE
v2ray-geodata: bump to latest version

### DIFF
--- a/v2ray-geodata/Makefile
+++ b/v2ray-geodata/Makefile
@@ -12,22 +12,22 @@ PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
 include $(INCLUDE_DIR)/package.mk
 
-GEOIP_VER:=202402150038
+GEOIP_VER:=202402220038
 GEOIP_FILE:=geoip.dat.$(GEOIP_VER)
 define Download/geoip
   URL:=https://github.com/v2fly/geoip/releases/download/$(GEOIP_VER)/
   URL_FILE:=geoip.dat
   FILE:=$(GEOIP_FILE)
-  HASH:=d29a781c15da854f708b81c1838598f1a340b04ef3546cf128a57f44a27cdd42
+  HASH:=331c5031528f577dde3d63681d32a15693aace4e38095d40dbe3f751e0db5536
 endef
 
-GEOSITE_VER:=20240217140518
+GEOSITE_VER:=20240221053250
 GEOSITE_FILE:=dlc.dat.$(GEOSITE_VER)
 define Download/geosite
   URL:=https://github.com/v2fly/domain-list-community/releases/download/$(GEOSITE_VER)/
   URL_FILE:=dlc.dat
   FILE:=$(GEOSITE_FILE)
-  HASH:=ebf75a4f97aee4d744a35c10513063ebd63d42fe8ec166ecd26893eff074d9f2
+  HASH:=d2ef9bd9cac2678088f5494b888bf9eecdad385dc2b5689e6c7d56e4d97173a3
 endef
 
 define Package/v2ray-geodata/template


### PR DESCRIPTION
btw:  
the github actions "Auto update packages v2" did not set "is_update_geodata" ,  so the automatic update is disabled/skipped.  

is it intentional ?