### PR TITLE
shadowsocksr-libev: drop libopenssl-legacy depends

### DIFF
--- a/shadowsocksr-libev/Makefile
+++ b/shadowsocksr-libev/Makefile
@@ -34,7 +34,7 @@ define Package/shadowsocksr-libev/Default
     SUBMENU:=Web Servers/Proxies
     TITLE:=shadowsocksr-libev ssr-$(1)
     URL:=https://github.com/shadowsocksrr/shadowsocksr-libev
-    DEPENDS:=+libev +libsodium +libopenssl +libpthread +libpcre2 +libudns +zlib +libopenssl-legacy
+    DEPENDS:=+libev +libsodium +libopenssl +libpthread +libpcre2 +libudns +zlib
   endef
 
   define Package/shadowsocksr-libev-ssr-$(1)/install


### PR DESCRIPTION
* libopenssl-legacy seems to be only available in openwrt-23.05 openssl3.
* remove this dependency to ensure proper build of the old OpenWrt branch.