### PR TITLE
sing-box: add dependency for auto_redirect

### DIFF
--- a/sing-box/Makefile
+++ b/sing-box/Makefile
@@ -38,6 +38,7 @@ define Package/$(PKG_NAME)
     +ca-bundle \
     +kmod-inet-diag \
     +kmod-netlink-diag \
+    +kmod-nft-nat6 \
     +kmod-tun
 endef
 


### PR DESCRIPTION
and also make sing-box can run indentpently, without any luci program.