### PR TITLE
fix: at encrypt in encrypt.c

### DIFF
--- a/shadowsocksr-libev/src/server/encrypt.c
+++ b/shadowsocksr-libev/src/server/encrypt.c
@@ -320,8 +320,8 @@ static void
 merge(uint8_t *left, int llength, uint8_t *right,
       int rlength, uint32_t salt, uint64_t key)
 {
-    uint8_t *ltmp = (uint8_t *)malloc(llength * sizeof(uint8_t));
-    uint8_t *rtmp = (uint8_t *)malloc(rlength * sizeof(uint8_t));
+    uint8_t *ltmp = (uint8_t *)malloc(llength);
+    uint8_t *rtmp = (uint8_t *)malloc(rlength);
 
     uint8_t *ll = ltmp;
     uint8_t *rr = rtmp;
@@ -783,7 +783,7 @@ cipher_context_set_iv(cipher_ctx_t *ctx, uint8_t *iv, size_t iv_len,
     }
 
     if (!enc) {
-        memcpy(ctx->iv, iv, iv_len);
+        memcpy(ctx->iv, iv, min(iv_len, MAX_IV_LENGTH));
     }
 
     if (enc_method >= SALSA20) {
@@ -803,8 +803,8 @@ cipher_context_set_iv(cipher_ctx_t *ctx, uint8_t *iv, size_t iv_len,
 #ifdef USE_CRYPTO_APPLECC
     cipher_cc_t *cc = &ctx->cc;
     if (cc->valid == kCCContextValid) {
-        memcpy(cc->iv, iv, iv_len);
-        memcpy(cc->key, true_key, enc_key_len);
+        memcpy(cc->iv, iv, min(iv_len, MAX_IV_LENGTH));
+        memcpy(cc->key, true_key, min(enc_key_len, MAX_KEY_LENGTH));
         cc->iv_len  = iv_len;
         cc->key_len = enc_key_len;
         cc->encrypt = enc ? kCCEncrypt : kCCDecrypt;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `shadowsocksr-libev/src/server/encrypt.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `shadowsocksr-libev/src/server/encrypt.c:786` |

**Description**: At encrypt.c lines 786 and 806, the server copies attacker-controlled IV data into fixed-size heap buffers (ctx->iv and cc->iv) using the attacker-supplied iv_len value without first validating it against the actual allocated buffer size. An attacker who sends a crafted network packet with an oversized IV length field (e.g., 256 bytes for a cipher expecting 16 bytes) will cause memcpy to write beyond the end of the destination buffer, corrupting adjacent heap memory including potential function pointers and allocator metadata. Line 807 has the same issue for the encryption key length.

## Changes
- `shadowsocksr-libev/src/server/encrypt.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
